### PR TITLE
fix undefined _autop_newline_preservation_helper() 

### DIFF
--- a/app/WpTrait.php
+++ b/app/WpTrait.php
@@ -183,7 +183,11 @@ trait WpTrait
 
         return $pee;
     }
-
+    
+    function _autop_newline_preservation_helper($matches)
+    {
+        return str_replace("\n", '<WPPreserveNewline />', $matches[0]);
+    }
 /**
  * Replace characters or phrases within HTML elements only.
  *


### PR DESCRIPTION
Because line 155 has execution to _autop_newline_preservation_helper()
Cause the program to crash
Call to undefined method Illuminate\Database\Query\Builder::_autop_newline_preservation_helper()